### PR TITLE
fix: reject command that isn't pause if not paused

### DIFF
--- a/Code/Machine/Logic-Unit/Logic-control/Logic-control.ino
+++ b/Code/Machine/Logic-Unit/Logic-control/Logic-control.ino
@@ -274,6 +274,10 @@ void handleRemote(String receivedCommand) {
       commandID = 0;
     }
   }
+  //Reject command if machine is not paused and command isnt pause command (avoid errors during combat)
+  if (!paused && commandID != 45) {
+    commandID = 0;
+  }
   //Command handling, if command is 0 (invalid) or 37 (synch) do nothing
   switch (commandID) {
     case 22:


### PR DESCRIPTION
make machine reject any command that isn't a pause command if the machine is not paused (i.e., when timer is going, machine can only be paused)